### PR TITLE
(GH-7) Fix multiple threads in one call

### DIFF
--- a/src/Cake.Prca.Tests/FakePullRequestSystem.cs
+++ b/src/Cake.Prca.Tests/FakePullRequestSystem.cs
@@ -49,11 +49,13 @@
             return this.modifiedFiles;
         }
 
-        public override void MarkThreadAsFixed(IPrcaDiscussionThread thread)
+        public override void MarkThreadsAsFixed(IEnumerable<IPrcaDiscussionThread> threads)
         {
-            thread.NotNull(nameof(thread));
+            // ReSharper disable once PossibleMultipleEnumeration
+            threads.NotNull(nameof(threads));
 
-            this.threadsMarkedAsFixed.Add(thread);
+            // ReSharper disable once PossibleMultipleEnumeration
+            this.threadsMarkedAsFixed.AddRange(threads);
         }
 
         public override void PostDiscussionThreads(IEnumerable<ICodeAnalysisIssue> issues, string commentSource)

--- a/src/Cake.Prca/Orchestrator.cs
+++ b/src/Cake.Prca/Orchestrator.cs
@@ -227,14 +227,11 @@
                 return;
             }
 
-            // Comments that do not match HasElements input issues are said to be resolved.
-            var resolvedThreads = this.GetResolvedThreads(existingThreads, issueComments);
+            var resolvedThreads =
+                this.GetResolvedThreads(existingThreads, issueComments).ToList();
 
-            foreach (var thread in resolvedThreads)
-            {
-                this.log.Verbose("Mark thread with ID {0} as fixed...", thread.Id);
-                this.pullRequestSystem.MarkThreadAsFixed(thread);
-            }
+            this.log.Verbose("Mark {0} threads as fixed...", resolvedThreads.Count);
+            this.pullRequestSystem.MarkThreadsAsFixed(resolvedThreads);
         }
 
         /// <summary>

--- a/src/Cake.Prca/PullRequests/IPullRequestSystem.cs
+++ b/src/Cake.Prca/PullRequests/IPullRequestSystem.cs
@@ -18,10 +18,10 @@
         IEnumerable<IPrcaDiscussionThread> FetchActiveDiscussionThreads(string commentSource);
 
         /// <summary>
-        /// Marks a discussion thread as resolved.
+        /// Marks a list of discussion threads as resolved.
         /// </summary>
-        /// <param name="thread">Thread to mark as fixed.</param>
-        void MarkThreadAsFixed(IPrcaDiscussionThread thread);
+        /// <param name="threads">Threads to mark as fixed.</param>
+        void MarkThreadsAsFixed(IEnumerable<IPrcaDiscussionThread> threads);
 
         /// <summary>
         /// Returns a list of all files modified in a pull request.

--- a/src/Cake.Prca/PullRequests/PullRequestSystem.cs
+++ b/src/Cake.Prca/PullRequests/PullRequestSystem.cs
@@ -33,7 +33,7 @@
         public abstract IEnumerable<FilePath> GetModifiedFilesInPullRequest();
 
         /// <inheritdoc/>
-        public abstract void MarkThreadAsFixed(IPrcaDiscussionThread thread);
+        public abstract void MarkThreadsAsFixed(IEnumerable<IPrcaDiscussionThread> threads);
 
         /// <inheritdoc/>
         public abstract void PostDiscussionThreads(IEnumerable<ICodeAnalysisIssue> issues, string commentSource);


### PR DESCRIPTION
Change IPullRequestSystem.MarkThreadAsFixed to allow multiple threads to be resolved in one call

Fixes #7 