### PR TITLE
(GH-6) Allow to pass issues and discussion threads not linked to a file

### DIFF
--- a/src/Cake.Prca.Tests/Cake.Prca.Tests.csproj
+++ b/src/Cake.Prca.Tests/Cake.Prca.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="PrcaFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Issues\StringPathExtensionsTests.cs" />
+    <Compile Include="PullRequests\PrcaDiscussionThreadTests.cs" />
     <Compile Include="PullRequests\PullRequestSystemTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.Prca.Tests/Issues/CodeAnalysisIssueTests.cs
+++ b/src/Cake.Prca.Tests/Issues/CodeAnalysisIssueTests.cs
@@ -8,36 +8,6 @@
     {
         public sealed class TheCodeAnalysisIssueCtor
         {
-            [Fact]
-            public void Should_Throw_If_File_Path_Is_Null()
-            {
-                // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(null, 100, "Foo", 1, "Bar"));
-
-                // Then
-                result.IsArgumentNullException("filePath");
-            }
-
-            [Fact]
-            public void Should_Throw_If_File_Path_Is_Empty()
-            {
-                // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(string.Empty, 100, "Foo", 1, "Bar"));
-
-                // Then
-                result.IsArgumentOutOfRangeException("filePath");
-            }
-
-            [Fact]
-            public void Should_Throw_If_File_Path_Is_WhiteSpace()
-            {
-                // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(" ", 100, "Foo", 1, "Bar"));
-
-                // Then
-                result.IsArgumentOutOfRangeException("filePath");
-            }
-
             [Theory]
             [InlineData(@"foo<bar")]
             public void Should_Throw_If_File_Path_Is_Invalid(string filePath)
@@ -66,7 +36,7 @@
             public void Should_Throw_If_Line_Is_Negative()
             {
                 // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(@"\src\foo.cs", -1, "Foo", 1, "Bar"));
+                var result = Record.Exception(() => new CodeAnalysisIssue(@"src\foo.cs", -1, "Foo", 1, "Bar"));
 
                 // Then
                 result.IsArgumentOutOfRangeException("line");
@@ -76,7 +46,17 @@
             public void Should_Throw_If_Line_Is_Zero()
             {
                 // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(@"\src\foo.cs", 0, "Foo", 1, "Bar"));
+                var result = Record.Exception(() => new CodeAnalysisIssue(@"src\foo.cs", 0, "Foo", 1, "Bar"));
+
+                // Then
+                result.IsArgumentOutOfRangeException("line");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Line_Is_Set_But_No_File()
+            {
+                // Given / When
+                var result = Record.Exception(() => new CodeAnalysisIssue(null, 10, "Foo", 1, "Bar"));
 
                 // Then
                 result.IsArgumentOutOfRangeException("line");
@@ -86,7 +66,7 @@
             public void Should_Throw_If_Message_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(@"\src\foo.cs", 100, null, 1, "Bar"));
+                var result = Record.Exception(() => new CodeAnalysisIssue(@"src\foo.cs", 100, null, 1, "Bar"));
 
                 // Then
                 result.IsArgumentNullException("message");
@@ -96,7 +76,7 @@
             public void Should_Throw_If_Message_Is_Empty()
             {
                 // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(@"\src\foo.cs", 100, string.Empty, 1, "Bar"));
+                var result = Record.Exception(() => new CodeAnalysisIssue(@"src\foo.cs", 100, string.Empty, 1, "Bar"));
 
                 // Then
                 result.IsArgumentOutOfRangeException("message");
@@ -106,7 +86,7 @@
             public void Should_Throw_If_Message_Is_WhiteSpace()
             {
                 // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(@"\src\foo.cs", 100, " ", 1, "Bar"));
+                var result = Record.Exception(() => new CodeAnalysisIssue(@"src\foo.cs", 100, " ", 1, "Bar"));
 
                 // Then
                 result.IsArgumentOutOfRangeException("message");
@@ -116,10 +96,40 @@
             public void Should_Throw_If_Rule_Is_Null()
             {
                 // Given / When
-                var result = Record.Exception(() => new CodeAnalysisIssue(@"\src\foo.cs", 100, "foo", 1, null));
+                var result = Record.Exception(() => new CodeAnalysisIssue(@"src\foo.cs", 100, "foo", 1, null));
 
                 // Then
                 result.IsArgumentNullException("rule");
+            }
+
+            [Fact]
+            public void Should_Handle_File_Paths_Which_Are_Null()
+            {
+                // Given / When
+                var issue = new CodeAnalysisIssue(null, null, "Foo", 1, "Bar");
+
+                // Then
+                issue.AffectedFileRelativePath.ShouldBe(null);
+            }
+
+            [Fact]
+            public void Should_Handle_File_Paths_Which_Are_Empty()
+            {
+                // Given / When
+                var issue = new CodeAnalysisIssue(string.Empty, null, "Foo", 1, "Bar");
+
+                // Then
+                issue.AffectedFileRelativePath.ShouldBe(null);
+            }
+
+            [Fact]
+            public void Should_Handle_File_Paths_Which_Are_WhiteSpace()
+            {
+                // Given / When
+                var issue = new CodeAnalysisIssue(" ", null, "Foo", 1, "Bar");
+
+                // Then
+                issue.AffectedFileRelativePath.ShouldBe(null);
             }
 
             [Theory]

--- a/src/Cake.Prca.Tests/PullRequests/PrcaDiscussionThreadTests.cs
+++ b/src/Cake.Prca.Tests/PullRequests/PrcaDiscussionThreadTests.cs
@@ -1,0 +1,143 @@
+﻿namespace Cake.Prca.Tests.PullRequests
+{
+    using System.Collections.Generic;
+    using Prca.PullRequests;
+    using Shouldly;
+    using Xunit;
+
+    public class PrcaDiscussionThreadTests
+    {
+        public sealed class ThePrcaDiscussionThreadCtor
+        {
+            [Theory]
+            [InlineData(@"c:\src\foo.cs")]
+            [InlineData(@"/foo")]
+            [InlineData(@"\foo")]
+            public void Should_Throw_If_File_Path_Is_Absolute(string filePath)
+            {
+                // Given / When
+                var result = Record.Exception(() => new PrcaDiscussionThread(1, PrcaDiscussionStatus.Active, filePath, new List<IPrcaDiscussionComment>()));
+
+                // Then
+                result.IsArgumentOutOfRangeException("filePath");
+            }
+
+            [Fact]
+            public void Should_Throw_If_Comments_Is_Null()
+            {
+                // Given / When
+                var result = Record.Exception(() => new PrcaDiscussionThread(1, PrcaDiscussionStatus.Active, @"foo.cs", null));
+
+                // Then
+                result.IsArgumentNullException("comments");
+            }
+
+            [Fact]
+            public void Should_Handle_File_Paths_Which_Are_Null()
+            {
+                // Given / When
+                var thread =
+                    new PrcaDiscussionThread(
+                        1,
+                        PrcaDiscussionStatus.Active,
+                        null,
+                        new List<IPrcaDiscussionComment>());
+
+                // Then
+                thread.AffectedFileRelativePath.ShouldBe(null);
+            }
+
+            [Theory]
+            [InlineData(int.MinValue)]
+            [InlineData(0)]
+            [InlineData(int.MaxValue)]
+            public void Should_Set_Id(int id)
+            {
+                // Given / When
+                var thread =
+                    new PrcaDiscussionThread(
+                        id,
+                        PrcaDiscussionStatus.Active,
+                        "foo.cs",
+                        new List<IPrcaDiscussionComment>());
+
+                // Then
+                thread.Id.ShouldBe(id);
+            }
+
+            [Theory]
+            [InlineData(PrcaDiscussionStatus.Active)]
+            [InlineData(PrcaDiscussionStatus.Resolved)]
+            public void Should_Set_Status(PrcaDiscussionStatus status)
+            {
+                // Given / When
+                var thread =
+                    new PrcaDiscussionThread(
+                        1,
+                        status,
+                        "foo.cs",
+                        new List<IPrcaDiscussionComment>());
+
+                // Then
+                thread.Status.ShouldBe(status);
+            }
+
+            [Fact]
+            public void Should_Set_Comments()
+            {
+                // Given
+                var comments =
+                    new List<IPrcaDiscussionComment>
+                    {
+                    new PrcaDiscussionComment
+                    {
+                        Content = "Foo",
+                        IsDeleted = false
+                    },
+                    new PrcaDiscussionComment
+                    {
+                        Content = "Bar",
+                        IsDeleted = true
+                    }
+                    };
+
+                // When
+                var thread =
+                    new PrcaDiscussionThread(
+                        1,
+                        PrcaDiscussionStatus.Active,
+                        "foo.cs",
+                        comments);
+
+                // Then
+                thread.Comments.ShouldContain(comment => comments.Contains(comment), comments.Count);
+            }
+
+            [Theory]
+            [InlineData(@"foo", @"foo")]
+            [InlineData(@"foo\bar", @"foo/bar")]
+            [InlineData(@"foo/bar", @"foo/bar")]
+            [InlineData(@"foo\bar\", @"foo/bar")]
+            [InlineData(@"foo/bar/", @"foo/bar")]
+            [InlineData(@".\foo", @"foo")]
+            [InlineData(@"./foo", @"foo")]
+            [InlineData(@"foo\..\bar", @"foo/../bar")]
+            [InlineData(@"foo/../bar", @"foo/../bar")]
+            public void Should_Set_File_Path(string filePath, string expectedFilePath)
+            {
+                // Given / When
+                // Given / When
+                var thread =
+                    new PrcaDiscussionThread(
+                        1,
+                        PrcaDiscussionStatus.Active,
+                        filePath,
+                        new List<IPrcaDiscussionComment>());
+
+                // Then
+                thread.AffectedFileRelativePath.ToString().ShouldBe(expectedFilePath);
+                thread.AffectedFileRelativePath.IsRelative.ShouldBe(true, "File path was not set as relative.");
+            }
+        }
+    }
+}

--- a/src/Cake.Prca/IssueFilterer.cs
+++ b/src/Cake.Prca/IssueFilterer.cs
@@ -120,6 +120,7 @@
             var result =
                 issues
                     .Where(issue =>
+                        issue.AffectedFileRelativePath == null ||
                         modifiedFilesHashSet.Contains(
                             issue.AffectedFileRelativePath.MakeAbsolute(this.settings.RepositoryRoot).ToString()))
                     .ToList();

--- a/src/Cake.Prca/Issues/ICodeAnalysisIssue.cs
+++ b/src/Cake.Prca/Issues/ICodeAnalysisIssue.cs
@@ -10,6 +10,7 @@
         /// <summary>
         /// Gets the path to the file affacted by the issue.
         /// The path is relative to the repository root.
+        /// Can be <c>null</c> if issue is not related to a change in a file.
         /// </summary>
         FilePath AffectedFileRelativePath { get; }
 

--- a/src/Cake.Prca/Orchestrator.cs
+++ b/src/Cake.Prca/Orchestrator.cs
@@ -57,6 +57,23 @@
         }
 
         /// <summary>
+        /// Checks if file path from an <see cref="ICodeAnalysisIssue"/> and <see cref="IPrcaDiscussionThread"/>
+        /// are matching.
+        /// </summary>
+        /// <param name="issue">Issue to check.</param>
+        /// <param name="thread">Comment thread to check.</param>
+        /// <returns><c>true</c> if both paths are matching or if both paths are set to <c>null</c>.</returns>
+        private static bool FilePathsAreMatching(ICodeAnalysisIssue issue, IPrcaDiscussionThread thread)
+        {
+            return
+                (issue.AffectedFileRelativePath == null && thread.AffectedFileRelativePath == null) ||
+                (
+                    issue.AffectedFileRelativePath != null &&
+                    thread.AffectedFileRelativePath != null &&
+                    thread.AffectedFileRelativePath.ToString() == issue.AffectedFileRelativePath.ToString());
+        }
+
+        /// <summary>
         /// Posts new issues, ignoring duplicate comments and resolves comments that were open in an old iteration
         /// of the pull request.
         /// </summary>
@@ -168,7 +185,7 @@
                 where
                     thread != null &&
                     thread.Status == PrcaDiscussionStatus.Active &&
-                    thread.AffectedFileRelativePath.ToString() == issue.AffectedFileRelativePath.ToString() &&
+                    FilePathsAreMatching(issue, thread) &&
                     thread.CommentSource == this.settings.CommentSource
                 select thread).ToList();
 

--- a/src/Cake.Prca/PullRequests/IPrcaDiscussionThread.cs
+++ b/src/Cake.Prca/PullRequests/IPrcaDiscussionThread.cs
@@ -21,6 +21,7 @@
         /// <summary>
         /// Gets or sets the path to the file where the message should be posted.
         /// The path needs to be relative to the repository root.
+        /// Can be <c>null</c> if discussion is not related to a change in a file.
         /// </summary>
         FilePath AffectedFileRelativePath { get; set; }
 

--- a/src/Cake.Prca/PullRequests/PrcaDiscussionThread.cs
+++ b/src/Cake.Prca/PullRequests/PrcaDiscussionThread.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cake.Prca.PullRequests
 {
+    using System;
     using System.Collections.Generic;
     using Core.IO;
 
@@ -15,22 +16,32 @@
         /// </summary>
         /// <param name="id">ID of the discussion thread.</param>
         /// <param name="status">A value if the thread is active or already fixed.</param>
-        /// <param name="affectedFileRelativePath">The path to the file where the message should be posted.
-        /// The path needs to be relative to the repository root.</param>
+        /// <param name="filePath">The path to the file where the message should be posted.
+        /// The path needs to be relative to the repository root.
+        /// Can be <c>null</c> if discussion is not related to a change in a file.</param>
         /// <param name="comments">All the comments of this thread.</param>
         public PrcaDiscussionThread(
             int id,
             PrcaDiscussionStatus status,
-            FilePath affectedFileRelativePath,
+            FilePath filePath,
             IEnumerable<IPrcaDiscussionComment> comments)
         {
             // ReSharper disable once PossibleMultipleEnumeration
             comments.NotNull(nameof(comments));
-            affectedFileRelativePath.NotNull(nameof(affectedFileRelativePath));
+
+            // File path needs to be relative to the repository root.
+            if (filePath != null)
+            {
+                if (!filePath.IsRelative)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(filePath), "File path needs to be relative to the repository root.");
+                }
+
+                this.AffectedFileRelativePath = filePath;
+            }
 
             this.Id = id;
             this.Status = status;
-            this.AffectedFileRelativePath = affectedFileRelativePath;
 
             // ReSharper disable once PossibleMultipleEnumeration
             this.comments.AddRange(comments);


### PR DESCRIPTION
Allow issues providers to pass issues not linked to a file. Same for discussion threads provided by pull request systems.

These issues are passed to the pull request system which need to define if it can handle them or otherwise can output a message.

Fixes #6 