### PR TITLE
(GH-15) Test for valid path for code analysis issue

### DIFF
--- a/src/Cake.Prca.Tests/Issues/CodeAnalysisIssueTests.cs
+++ b/src/Cake.Prca.Tests/Issues/CodeAnalysisIssueTests.cs
@@ -37,6 +37,17 @@
         }
 
         [Theory]
+        [InlineData(@"foo<bar")]
+        public void Should_Throw_If_File_Path_Is_Invalid(string filePath)
+        {
+            // Given / When
+            var result = Record.Exception(() => new CodeAnalysisIssue(filePath, 100, "Foo", 1, "Bar"));
+
+            // Then
+            result.IsArgumentException("filePath");
+        }
+
+        [Theory]
         [InlineData(@"c:\src\foo.cs")]
         [InlineData(@"/foo")]
         [InlineData(@"\foo")]

--- a/src/Cake.Prca/Issues/CodeAnalysisIssue.cs
+++ b/src/Cake.Prca/Issues/CodeAnalysisIssue.cs
@@ -26,6 +26,11 @@
             message.NotNullOrWhiteSpace(nameof(message));
             rule.NotNull(nameof(rule));
 
+            if (!filePath.IsValidPath())
+            {
+                throw new ArgumentException("Invalid path", nameof(filePath));
+            }
+
             // File path needs to be relative to the repository root.
             this.AffectedFileRelativePath = filePath;
             if (!this.AffectedFileRelativePath.IsRelative)


### PR DESCRIPTION
Validates path passed to `CodeAnalysisIssue` ctor and throws appropriate exception if invalid.

Fixes #15 