### PR TITLE
(GH-17) Support different formats for pull request comments

### DIFF
--- a/src/Cake.Prca.Tests/FakeCodeAnalysisProvider.cs
+++ b/src/Cake.Prca.Tests/FakeCodeAnalysisProvider.cs
@@ -7,6 +7,7 @@
     public class FakeCodeAnalysisProvider : CodeAnalysisProvider
     {
         private readonly List<ICodeAnalysisIssue> issues = new List<ICodeAnalysisIssue>();
+        private PrcaCommentFormat format;
 
         public FakeCodeAnalysisProvider(ICakeLog log)
             : base(log)
@@ -27,13 +28,16 @@
 
         public ReportCodeAnalysisIssuesToPullRequestSettings PrcaSettings { get; private set; }
 
+        public PrcaCommentFormat Format => this.format;
+
         public override void Initialize(ReportCodeAnalysisIssuesToPullRequestSettings settings)
         {
             this.PrcaSettings = settings;
         }
 
-        public override IEnumerable<ICodeAnalysisIssue> ReadIssues()
+        public override IEnumerable<ICodeAnalysisIssue> ReadIssues(PrcaCommentFormat format)
         {
+            this.format = format;
             return this.issues;
         }
     }

--- a/src/Cake.Prca.Tests/FakePullRequestSystem.cs
+++ b/src/Cake.Prca.Tests/FakePullRequestSystem.cs
@@ -45,9 +45,16 @@
 
         public IEnumerable<ICodeAnalysisIssue> PostedIssues => this.postedIssues;
 
+        public PrcaCommentFormat CommentFormat { get; set; } = PrcaCommentFormat.PlainText;
+
         public override void Initialize(ReportCodeAnalysisIssuesToPullRequestSettings settings)
         {
             this.PrcaSettings = settings;
+        }
+
+        public override PrcaCommentFormat GetPreferredCommentFormat()
+        {
+            return this.CommentFormat;
         }
 
         public override IEnumerable<IPrcaDiscussionThread> FetchActiveDiscussionThreads(string commentSource)

--- a/src/Cake.Prca.Tests/OrchestratorTests.cs
+++ b/src/Cake.Prca.Tests/OrchestratorTests.cs
@@ -107,6 +107,31 @@
 
         public sealed class TheRunMethod
         {
+            [Theory]
+            [InlineData(PrcaCommentFormat.Undefined)]
+            [InlineData(PrcaCommentFormat.Html)]
+            [InlineData(PrcaCommentFormat.Markdown)]
+            [InlineData(PrcaCommentFormat.PlainText)]
+            public void Should_Use_The_Correct_Comment_Format(PrcaCommentFormat format)
+            {
+                // Given
+                var fixture = new PrcaFixture();
+                fixture.PullRequestSystem =
+                    new FakePullRequestSystem(
+                        fixture.Log,
+                        new List<IPrcaDiscussionThread>(),
+                        new List<FilePath>())
+                    {
+                        CommentFormat = format
+                    };
+
+                // When
+                fixture.RunOrchestrator();
+
+                // Then
+                fixture.CodeAnalysisProviders.ShouldAllBe(x => x.Format == format);
+            }
+
             [Fact]
             public void Should_Initialize_Code_Analysis_Provider()
             {

--- a/src/Cake.Prca/Cake.Prca.csproj
+++ b/src/Cake.Prca/Cake.Prca.csproj
@@ -66,6 +66,7 @@
     <Compile Include="PrcaAliases.cs" />
     <Compile Include="PrcaException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PrcaCommentFormat.cs" />
     <Compile Include="PullRequests\PrcaDiscussionComment.cs" />
     <Compile Include="PullRequests\PrcaDiscussionStatus.cs" />
     <Compile Include="PullRequests\PrcaDiscussionThread.cs" />

--- a/src/Cake.Prca/Issues/CodeAnalysisProvider.cs
+++ b/src/Cake.Prca/Issues/CodeAnalysisProvider.cs
@@ -28,6 +28,6 @@
         public abstract void Initialize(ReportCodeAnalysisIssuesToPullRequestSettings settings);
 
         /// <inheritdoc/>
-        public abstract IEnumerable<ICodeAnalysisIssue> ReadIssues();
+        public abstract IEnumerable<ICodeAnalysisIssue> ReadIssues(PrcaCommentFormat format);
     }
 }

--- a/src/Cake.Prca/Issues/ICodeAnalysisProvider.cs
+++ b/src/Cake.Prca/Issues/ICodeAnalysisProvider.cs
@@ -16,7 +16,8 @@
         /// <summary>
         /// Gets all code analysis issues.
         /// </summary>
+        /// <param name="format">Preferred format of the comments.</param>
         /// <returns>List of code analysis issues</returns>
-        IEnumerable<ICodeAnalysisIssue> ReadIssues();
+        IEnumerable<ICodeAnalysisIssue> ReadIssues(PrcaCommentFormat format);
     }
 }

--- a/src/Cake.Prca/Orchestrator.cs
+++ b/src/Cake.Prca/Orchestrator.cs
@@ -57,6 +57,9 @@
             this.log.Verbose("Initialize pull request system...");
             this.pullRequestSystem.Initialize(this.settings);
 
+            var format = this.pullRequestSystem.GetPreferredCommentFormat();
+            this.log.Verbose("Pull request system prefers comments in {0} format.", format);
+
             var issues = new List<ICodeAnalysisIssue>();
             foreach (var codeAnalysisProvider in this.codeAnalysisProviders)
             {
@@ -64,7 +67,7 @@
                 codeAnalysisProvider.Initialize(this.settings);
 
                 this.log.Verbose("Reading issues from {0}...", codeAnalysisProvider.GetType().Name);
-                var currentIssues = codeAnalysisProvider.ReadIssues().ToList();
+                var currentIssues = codeAnalysisProvider.ReadIssues(format).ToList();
                 this.log.Verbose(
                     "Found {0} issues using issue provider {1}...",
                     currentIssues.Count,

--- a/src/Cake.Prca/PrcaCommentFormat.cs
+++ b/src/Cake.Prca/PrcaCommentFormat.cs
@@ -1,0 +1,28 @@
+﻿namespace Cake.Prca
+{
+    /// <summary>
+    /// Possible format options for comments in the pull request system
+    /// </summary>
+    public enum PrcaCommentFormat
+    {
+        /// <summary>
+        /// Undefined format.
+        /// </summary>
+        Undefined,
+
+        /// <summary>
+        /// Plain text.
+        /// </summary>
+        PlainText,
+
+        /// <summary>
+        /// Hypertext markup language.
+        /// </summary>
+        Html,
+
+        /// <summary>
+        /// Markdown syntax.
+        /// </summary>
+        Markdown
+    }
+}

--- a/src/Cake.Prca/PullRequests/IPullRequestSystem.cs
+++ b/src/Cake.Prca/PullRequests/IPullRequestSystem.cs
@@ -17,6 +17,12 @@
         void Initialize(ReportCodeAnalysisIssuesToPullRequestSettings settings);
 
         /// <summary>
+        /// Returns the preferred format for pull request comments.
+        /// </summary>
+        /// <returns>The preferred format for pull request comments</returns>
+        PrcaCommentFormat GetPreferredCommentFormat();
+
+        /// <summary>
         /// Returns a list of all active discussion threads.
         /// </summary>
         /// <param name="commentSource">Value used to indicate threads created by this addin.</param>

--- a/src/Cake.Prca/PullRequests/PullRequestSystem.cs
+++ b/src/Cake.Prca/PullRequests/PullRequestSystem.cs
@@ -30,6 +30,12 @@
         public abstract void Initialize(ReportCodeAnalysisIssuesToPullRequestSettings settings);
 
         /// <inheritdoc/>
+        public virtual PrcaCommentFormat GetPreferredCommentFormat()
+        {
+            return PrcaCommentFormat.PlainText;
+        }
+
+        /// <inheritdoc/>
         public abstract IEnumerable<IPrcaDiscussionThread> FetchActiveDiscussionThreads(string commentSource);
 
         /// <inheritdoc/>


### PR DESCRIPTION
Adds the possibility for the pull request system to define the prefered format for comments (Plain text, HTML, Markdown) which will be passed to the issue provider.

Fixes #17