### PR TITLE
(GH-24) Enhance ICodeAnalysisIssue interface with rule URL

### DIFF
--- a/src/Cake.Prca.Tests/Issues/CodeAnalysisIssueTests.cs
+++ b/src/Cake.Prca.Tests/Issues/CodeAnalysisIssueTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cake.Prca.Tests.Issues
 {
+    using System;
     using Prca.Issues;
     using Shouldly;
     using Xunit;
@@ -215,6 +216,32 @@
 
                 // Then
                 issue.Rule.ShouldBe(rule);
+            }
+
+            [Fact]
+            public void Should_Set_Rule_Url()
+            {
+                // Given
+                var ruleUrl = new Uri("http://google.com");
+
+                // When
+                var issue = new CodeAnalysisIssue(@"foo.cs", 100, "foo", 1, "foo", ruleUrl, "foo");
+
+                // Then
+                issue.RuleUrl.ShouldBe(ruleUrl);
+            }
+
+            [Fact]
+            public void Should_Set_Rule_Url_If_Null()
+            {
+                // Given
+                Uri ruleUrl = null;
+
+                // When
+                var issue = new CodeAnalysisIssue(@"foo.cs", 100, "foo", 1, "foo", ruleUrl, "foo");
+
+                // Then
+                issue.RuleUrl.ShouldBe(ruleUrl);
             }
 
             [Theory]

--- a/src/Cake.Prca/Issues/CodeAnalysisIssue.cs
+++ b/src/Cake.Prca/Issues/CodeAnalysisIssue.cs
@@ -28,6 +28,32 @@
             int priority,
             string rule,
             string providerType)
+            : this(filePath, line, message, priority, rule, null, providerType)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CodeAnalysisIssue"/> class.
+        /// </summary>
+        /// <param name="filePath">The path to the file affacted by the issue.
+        /// The path needs to be relative to the repository root.
+        /// <c>null</c> or <see cref="string.Empty"/> if issue is not related to a change in a file.</param>
+        /// <param name="line">The line in the file where the issues has occurred.
+        /// Nothing if the issue affects the whole file or an asssembly.</param>
+        /// <param name="message">The message of the code analysis issue.</param>
+        /// <param name="priority">The priority of the message used to filter out issues if there are more issues than
+        /// should be posted.</param>
+        /// <param name="rule">The rule of the code analysis issue.</param>
+        /// <param name="ruleUrl">The URL containing information about the failing rule.</param>
+        /// <param name="providerType">The type of the issue provider.</param>
+        public CodeAnalysisIssue(
+            string filePath,
+            int? line,
+            string message,
+            int priority,
+            string rule,
+            Uri ruleUrl,
+            string providerType)
         {
             line?.NotNegativeOrZero(nameof(line));
             message.NotNullOrWhiteSpace(nameof(message));
@@ -59,6 +85,7 @@
             this.Message = message;
             this.Priority = priority;
             this.Rule = rule;
+            this.RuleUrl = ruleUrl;
             this.ProviderType = providerType;
         }
 
@@ -76,6 +103,9 @@
 
         /// <inheritdoc/>
         public string Rule { get; }
+
+        /// <inheritdoc/>
+        public Uri RuleUrl { get; }
 
         /// <inheritdoc/>
         public string ProviderType { get; }

--- a/src/Cake.Prca/Issues/ICodeAnalysisIssue.cs
+++ b/src/Cake.Prca/Issues/ICodeAnalysisIssue.cs
@@ -1,5 +1,6 @@
 ﻿namespace Cake.Prca.Issues
 {
+    using System;
     using Core.IO;
 
     /// <summary>
@@ -35,6 +36,12 @@
         /// Gets the rule of the code analysis issue.
         /// </summary>
         string Rule { get; }
+
+        /// <summary>
+        /// Gets the URL containing information about the failing rule.
+        /// Can be <c>null</c> if the issue provider provides no URL.
+        /// </summary>
+        Uri RuleUrl { get; }
 
         /// <summary>
         /// Gets the type of the issue provider.


### PR DESCRIPTION
Gives the possibility for issue providers to return a URL containing a description of the rule.

Fixes #24 