### PR TITLE
(GH-41) Import Cake.Prca.Issues and Cake.Prca.PullRequests namespaces

### DIFF
--- a/src/Cake.Prca/PrcaAliases.cs
+++ b/src/Cake.Prca/PrcaAliases.cs
@@ -11,6 +11,8 @@
     /// Contains functionality related to writing code analysis issues to pull requests.
     /// </summary>
     [CakeAliasCategory(CakeAliasConstants.MainCakeAliasCategory)]
+    [CakeNamespaceImport("Cake.Prca.Issues")]
+    [CakeNamespaceImport("Cake.Prca.PullRequests")]
     public static class PrcaAliases
     {
         /// <summary>


### PR DESCRIPTION
Import Cake.Prca.Issues and Cake.Prca.PullRequests namespaces if one of the aliases is used.

Fixes #41 