### PR TITLE
(GH-58) Use new cake contrib icon

### DIFF
--- a/nuspec/nuget/Cake.Prca.nuspec
+++ b/nuspec/nuget/Cake.Prca.nuspec
@@ -10,7 +10,7 @@
     <description>The Pull Request Code Analysis Addin for Cake allows you to write issue found using any code analyzer or linter as comments to pull requests.</description>
     <licenseUrl>https://github.com/cake-contrib/Cake.Prca/blob/develop/LICENSE</licenseUrl>
     <projectUrl>http://cake-contrib.github.io/Cake.Prca.Website/</projectUrl>
-    <iconUrl>https://raw.githubusercontent.com/cake-build/graphics/aba74fb4cb5fe9454381af2cc70c870088229d5c/png/cake-medium.png</iconUrl>
+    <iconUrl>https://cdn.rawgit.com/cake-contrib/graphics/a5cf0f881c390650144b2243ae551d5b9f836196/png/cake-contrib-medium.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <copyright>Copyright © 2017 BBT Software AG, Root/Zermatt, Switzerland</copyright>
     <tags>Cake Script PullRequest CodeAnalysis Linting</tags>


### PR DESCRIPTION
Use new cake contrib icon.

Goes into 0.5.0 release.

Fixes #58